### PR TITLE
Set the base branch to test against with a .rubocop_lineup.yml file

### DIFF
--- a/lib/rubocop_lineup.rb
+++ b/lib/rubocop_lineup.rb
@@ -4,6 +4,7 @@ require "rubocop_lineup/version"
 require "rubocop_lineup/line_number_calculator"
 require "rubocop_lineup/diff_liner"
 require "rubocop_lineup/duck_punch_rubocop"
+require "yaml"
 
 module RubocopLineup
   # This defaults the parent branch to 'master'. This is a reasonable
@@ -12,11 +13,13 @@ module RubocopLineup
   # parent branch. There are ways to calculate the parent branch name
   # that cover common cases, but that's more complicated and may be added
   # in a future version.
-  def self.line_em_up(directory, parent_branch = "master")
+  def self.line_em_up(directory, base_branch = nil)
+    base_branch ||= base_branch_from_config || "master"
+
     @line_em_up ||= begin
       Dir.chdir(directory) do
         uncommitted = DiffLiner.diff_uncommitted.file_line_changes
-        committed_on_branch = DiffLiner.diff_branch(parent_branch).file_line_changes
+        committed_on_branch = DiffLiner.diff_branch(base_branch).file_line_changes
 
         # When a file has committed changes AND uncommitted_changes,
         # we will only include the lines from the uncommitted changes
@@ -30,5 +33,17 @@ module RubocopLineup
 
   def self.reset
     @line_em_up = nil
+  end
+
+  def self.rubocop_lineup_config_file
+    ".rubocop_lineup.yml"
+  end
+
+  def self.base_branch_from_config
+    return unless File.exist?(rubocop_lineup_config_file)
+
+    settings = YAML.load_file(rubocop_lineup_config_file)
+
+    settings[:base_branch]
   end
 end


### PR DESCRIPTION
We just changed the base branch of our main project from master to main and need a way of manually setting this now so that we don't mess other downstream users up. 

Example .rubocop_lineup.yml file:
```
---
:base_branch: "main"
```